### PR TITLE
explicitly import Module

### DIFF
--- a/Module/src/jab/ModuleBot.java
+++ b/Module/src/jab/ModuleBot.java
@@ -2,6 +2,7 @@ package jab;
 
 import jab.gun.*;
 import jab.module.*;
+import jab.module.Module;
 import jab.movement.*;
 import jab.radar.*;
 import jab.selectEnemy.*;


### PR DESCRIPTION
only importing the jab.module package created ambiguity in the IDE with an error message that confused some students. 
Adding an explicit import of the jab.module.Module class fixes this issue